### PR TITLE
Convert note images to mcp format for AI

### DIFF
--- a/easy-obsidian-mcp/package-lock.json
+++ b/easy-obsidian-mcp/package-lock.json
@@ -1,21 +1,23 @@
 {
     "name": "easy-obsidian-mcp",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "easy-obsidian-mcp",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "license": "ISC",
             "dependencies": {
                 "@clack/prompts": "^0.7.0",
                 "@modelcontextprotocol/sdk": "^1.8.0",
                 "dotenv": "^16.4.5",
+                "yargs": "^17.7.2",
                 "zod": "^3.23.8"
             },
             "devDependencies": {
                 "@types/node": "^20.14.2",
+                "@types/yargs": "^17.0.32",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.4.5"
             }
@@ -144,6 +146,23 @@
                 "undici-types": "~6.19.2"
             }
         },
+        "node_modules/@types/yargs": {
+            "version": "17.0.33",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "node_modules/@types/yargs-parser": {
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/accepts": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -178,6 +197,30 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/arg": {
@@ -239,6 +282,38 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
         },
         "node_modules/content-disposition": {
             "version": "1.0.0",
@@ -368,6 +443,12 @@
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
         "node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -401,6 +482,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/escape-html": {
@@ -530,6 +620,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -635,6 +734,15 @@
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-promise": {
@@ -835,6 +943,15 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/router": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1014,6 +1131,32 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1133,10 +1276,63 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/yn": {
             "version": "3.1.1",

--- a/easy-obsidian-mcp/src/index.ts
+++ b/easy-obsidian-mcp/src/index.ts
@@ -5,6 +5,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import { Obsidian } from "./obsidian";
+import path from "path";
 
 // --- Argument Parsing ---
 async function parseArgs() {
@@ -619,20 +620,100 @@ see dataview documentation for full syntax: https://blacksmithgu.github.io/obsid
           contentLength: content.length,
         });
 
-        const response = {
-          success: true,
-          request_id: queryId,
-          filepath: validatedArgs.filepath,
-          content_length: content.length,
-          retrieval_duration_ms: parseFloat(duration.toFixed(2)),
-          content: content, // The actual file content
-          meta: {
-            timestamp: new Date().toISOString(),
-            operation_type: "get_file_content",
-          },
+        // --- Parse image references in markdown content ---
+        const noteDir = path.posix.dirname(validatedArgs.filepath);
+
+        const markdownImageRegex = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g; // ![alt](path "title")
+        const wikilinkImageRegex = /!\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g; // ![[path|size]]
+        const htmlImgRegex = /<img\s+[^>]*src=["']([^"']+)["'][^>]*>/gi; // <img src="path">
+
+        const extractImageTargets = (markdown: string): string[] => {
+          const targets: string[] = [];
+          const add = (u: string) => {
+            if (u && !targets.includes(u)) targets.push(u);
+          };
+          let m: RegExpExecArray | null;
+          while ((m = markdownImageRegex.exec(markdown)) !== null) add(m[1]);
+          while ((m = wikilinkImageRegex.exec(markdown)) !== null) add(m[1]);
+          while ((m = htmlImgRegex.exec(markdown)) !== null) add(m[1]);
+          return targets;
         };
+
+        const isHttpUrl = (u: string) => /^https?:\/\//i.test(u);
+        const isDataUri = (u: string) => /^data:/i.test(u);
+        const parseDataUri = (u: string): { mimeType: string; base64Data: string } | null => {
+          const match = /^data:([^;]+);base64,(.*)$/i.exec(u);
+          if (!match) return null;
+          return { mimeType: match[1], base64Data: match[2] };
+        };
+
+        const normalizeVaultPath = (p: string): string => {
+          const norm = path.posix.normalize(p).replace(/^\/+/, "");
+          return norm;
+        };
+
+        const candidatePathsFor = (noteDirectory: string, ref: string): string[] => {
+          const cleanRef = ref.replace(/^\.\//, "");
+          const candidates: string[] = [];
+          if (cleanRef.startsWith("/")) {
+            candidates.push(normalizeVaultPath(cleanRef));
+          } else {
+            candidates.push(normalizeVaultPath(path.posix.join(noteDirectory, cleanRef)));
+            candidates.push(normalizeVaultPath(cleanRef));
+          }
+          return Array.from(new Set(candidates));
+        };
+
+        const refs = extractImageTargets(content);
+
+        // Fetch images for local refs; external http(s) refs are attached as URI
+        const imageContents: any[] = [];
+        const attachedMeta: Array<{ ref: string; resolved?: string; source: "data" | "uri" | "vault" | "skipped"; reason?: string; mimeType?: string }> = [];
+
+        for (const ref of refs) {
+          try {
+            if (isDataUri(ref)) {
+              const parsed = parseDataUri(ref);
+              if (parsed) {
+                imageContents.push({ type: "image", data: parsed.base64Data, mimeType: parsed.mimeType });
+                attachedMeta.push({ ref, source: "data", mimeType: parsed.mimeType });
+              } else {
+                attachedMeta.push({ ref, source: "skipped", reason: "unsupported data uri" });
+              }
+              continue;
+            }
+            if (isHttpUrl(ref)) {
+              imageContents.push({ type: "image", uri: ref });
+              attachedMeta.push({ ref, source: "uri" });
+              continue;
+            }
+
+            const candidates = candidatePathsFor(noteDir, ref);
+            let fetched = false;
+            for (const c of candidates) {
+              try {
+                const bin = await obsidian.getFileBinary(c);
+                imageContents.push({ type: "image", data: bin.base64Data, mimeType: bin.mimeType });
+                attachedMeta.push({ ref, resolved: c, source: "vault", mimeType: bin.mimeType });
+                fetched = true;
+                break;
+              } catch (e) {
+                // try next candidate
+              }
+            }
+            if (!fetched) {
+              attachedMeta.push({ ref, source: "skipped", reason: "not found in vault" });
+            }
+          } catch (e) {
+            attachedMeta.push({ ref, source: "skipped", reason: e instanceof Error ? e.message : String(e) });
+          }
+        }
+
         return {
-          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          content: [
+            { type: "text", text: content },
+            ...imageContents,
+          ],
         };
       } catch (error) {
         const endTime = performance.now();


### PR DESCRIPTION
Add `getFileBinary` method to Obsidian client to fetch images as base64 data for inclusion in MCP prompts.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3d7b2f9-8e6d-43e0-927d-186f7a644525">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3d7b2f9-8e6d-43e0-927d-186f7a644525">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

